### PR TITLE
Fix API call in getFireDetails() ...

### DIFF
--- a/fire-react-app/src/pages/Data.js
+++ b/fire-react-app/src/pages/Data.js
@@ -189,7 +189,7 @@ const Data = () => {
     };
     console.log("fetching fire details");
     const response = await axios.get(
-      `${process.env.REACT_APP_DJANGO_API_URL}fire/`,
+      process.env.REACT_APP_DJANGO_API_URL + "fire/",
       {
         params: {
           FOD_ID: id,


### PR DESCRIPTION
Using backticks seems to confuse react/webpack. This was the only API call still using that form so I converted to the form used by the other calls